### PR TITLE
Remove symbol validation in base.py

### DIFF
--- a/poloniex/api/base.py
+++ b/poloniex/api/base.py
@@ -61,8 +61,6 @@ class BasePublicApi:
 
     def get_params(self, command, **kwargs):
         currency_pair = kwargs.get("currency_pair")
-        if currency_pair and currency_pair not in constants.CURRENCY_PAIRS + ["all"]:
-            raise PoloniexError("Currency pair '{}' not available.".format(currency_pair))
 
         depth = kwargs.get("depth")
 
@@ -167,8 +165,6 @@ class BaseTradingApi:
 
     def get_params(self, command, **kwargs):
         currency_pair = kwargs.get("currency_pair")
-        if currency_pair and currency_pair not in constants.CURRENCY_PAIRS + ["all"]:
-            raise PoloniexError("Currency pair '{}' not available.".format(currency_pair))
 
         currency = kwargs.get("currency")
 


### PR DESCRIPTION
Do we need to validate symbols here? If so can it be based on the valid list of tickers polo keeps instead of an arbitrary constant file?

This patch got my system working again, but it isn't necessarily a total fix.
I hope there are tests to double check this doesn't break anything...